### PR TITLE
🔀 :: 업데이트 API  리팩토링 및 스퀘어 프로필 사용

### DIFF
--- a/git-application/src/main/kotlin/com/xquare/git/git/dto/FindAllUserResponse.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/git/dto/FindAllUserResponse.kt
@@ -11,6 +11,6 @@ data class FindUserElement(
     val userId: UUID,
     val name: String,
     val username: String,
-    val avatarUrl: String,
+    val profileFileName: String?,
     val contributions: Int,
 )

--- a/git-application/src/main/kotlin/com/xquare/git/git/spi/CommandGitPort.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/git/spi/CommandGitPort.kt
@@ -1,8 +1,10 @@
 package com.xquare.git.git.spi
 
 import com.xquare.git.git.model.Git
+import java.util.*
 
 interface CommandGitPort {
     suspend fun saveUser(git: Git)
     suspend fun updateGit(git: Git)
+    suspend fun updateContributionCount(gitAllInfo: List<Git>): Map<UUID, Int>
 }

--- a/git-application/src/main/kotlin/com/xquare/git/git/spi/QueryGitPort.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/git/spi/QueryGitPort.kt
@@ -8,5 +8,4 @@ interface QueryGitPort {
     suspend fun getGitByUserId(userId: UUID): Git?
     suspend fun getGitByUsername(username: String): Git?
     suspend fun getContributionCount(username: String): Int
-    suspend fun getAvatarUrl(username: String): String
 }

--- a/git-application/src/main/kotlin/com/xquare/git/git/usecase/FindAllGitUseCase.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/git/usecase/FindAllGitUseCase.kt
@@ -18,13 +18,14 @@ class FindAllGitUseCase(
         val userInfoRequest = FindUserInfoRequest(userIds)
         val gitUserInfoList = queryUserPort.getAllUserInfo(userInfoRequest).users
 
-        val response = gitInfoList.map {
+        val response = gitInfoList.map { gitInfo ->
+            val userInfo = gitUserInfoList.single { git -> git.id == gitInfo.userId }
             FindUserElement(
-                userId = it.userId,
-                name = gitUserInfoList.single { gitInfo -> gitInfo.id == it.userId }.name,
-                username = it.username,
-                avatarUrl = it.avatarUrl,
-                contributions = it.contributions,
+                userId = gitInfo.userId,
+                name = userInfo.name,
+                username = gitInfo.username,
+                profileFileName = userInfo.profileFileName,
+                contributions = gitInfo.contributions,
             )
         }
         return FindAllUserResponse(response)

--- a/git-application/src/main/kotlin/com/xquare/git/git/usecase/FindGitByCurrentUserIdUseCase.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/git/usecase/FindGitByCurrentUserIdUseCase.kt
@@ -10,18 +10,18 @@ import java.util.*
 @UseCase
 class FindGitByCurrentUserIdUseCase(
     private val queryGitPort: QueryGitPort,
-    private val queryUserPort: QueryUserPort
+    private val queryUserPort: QueryUserPort,
 ) {
     suspend fun execute(userId: UUID): FindUserElement {
         val gitUserInfo = queryGitPort.getGitByUserId(userId) ?: throw GitExceptions.NotFound()
         val nameAndProfileFileName = queryUserPort.getNameAndProfileFileName(userId)
-        
+
         return FindUserElement(
             userId = gitUserInfo.userId,
             name = nameAndProfileFileName.name,
             username = gitUserInfo.username,
             profileFileName = nameAndProfileFileName.profileFileName,
-            contributions = gitUserInfo.contributions
+            contributions = gitUserInfo.contributions,
         )
     }
 }

--- a/git-application/src/main/kotlin/com/xquare/git/git/usecase/FindGitByCurrentUserIdUseCase.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/git/usecase/FindGitByCurrentUserIdUseCase.kt
@@ -14,14 +14,14 @@ class FindGitByCurrentUserIdUseCase(
 ) {
     suspend fun execute(userId: UUID): FindUserElement {
         val gitUserInfo = queryGitPort.getGitByUserId(userId) ?: throw GitExceptions.NotFound()
-        return gitUserInfo.let {
-            FindUserElement(
-                userId = it.userId,
-                name = queryUserPort.getName(it.userId).name,
-                username = it.username,
-                avatarUrl = it.avatarUrl,
-                contributions = it.contributions
-            )
-        }
+        val nameAndProfileFileName = queryUserPort.getNameAndProfileFileName(userId)
+        
+        return FindUserElement(
+            userId = gitUserInfo.userId,
+            name = nameAndProfileFileName.name,
+            username = gitUserInfo.username,
+            profileFileName = nameAndProfileFileName.profileFileName,
+            contributions = gitUserInfo.contributions
+        )
     }
 }

--- a/git-application/src/main/kotlin/com/xquare/git/git/usecase/SaveUsernameUseCase.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/git/usecase/SaveUsernameUseCase.kt
@@ -12,14 +12,12 @@ class SaveUsernameUseCase(
     private val queryGitPort: QueryGitPort
 ) {
     suspend fun execute(currentUserId: UUID, username: String) {
-        val avatarUrl = queryGitPort.getAvatarUrl(username)
         val contributions = queryGitPort.getContributionCount(username)
 
         commandGitPort.saveUser(
             Git(
                 userId = currentUserId,
                 username = username,
-                avatarUrl = avatarUrl,
                 contributions = contributions
             )
         )

--- a/git-application/src/main/kotlin/com/xquare/git/git/usecase/UpdateGitUseCase.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/git/usecase/UpdateGitUseCase.kt
@@ -1,6 +1,7 @@
 package com.xquare.git.git.usecase
 
 import com.xquare.git.annotations.UseCase
+import com.xquare.git.git.exceptions.GitExceptions
 import com.xquare.git.git.spi.CommandGitPort
 import com.xquare.git.git.spi.QueryGitPort
 
@@ -10,12 +11,13 @@ class UpdateGitUseCase(
     private val commandGitPort: CommandGitPort
 ) {
     suspend fun execute() {
-        queryGitPort.getAllGit()
-            .map {
-                val updateContribution = queryGitPort.getContributionCount(it.username)
-                val updateAvatarUrl = queryGitPort.getAvatarUrl(it.username)
-                val updateGit = it.updateGit(updateAvatarUrl, updateContribution)
-                commandGitPort.updateGit(updateGit)
-            }
+        val gitAllInfo = queryGitPort.getAllGit()
+        val updateContributionMap = commandGitPort.updateContributionCount(gitAllInfo)
+
+        gitAllInfo.forEach { git ->
+            val updateContribution = updateContributionMap[git.userId] ?: throw GitExceptions.NotFound()
+            val updateGit = git.updateGit(updateContribution)
+            commandGitPort.updateGit(updateGit)
+        }
     }
 }

--- a/git-application/src/main/kotlin/com/xquare/git/user/dto/FindUserListResponse.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/user/dto/FindUserListResponse.kt
@@ -1,5 +1,6 @@
 package com.xquare.git.user.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
 data class FindUserListResponse(
@@ -9,4 +10,7 @@ data class FindUserListResponse(
 data class FindUserInfoElement(
     val id: UUID,
     val name: String,
+
+    @JsonProperty("profile_file_name")
+    val profileFileName: String?,
 )

--- a/git-application/src/main/kotlin/com/xquare/git/user/spi/QueryUserPort.kt
+++ b/git-application/src/main/kotlin/com/xquare/git/user/spi/QueryUserPort.kt
@@ -3,9 +3,9 @@ package com.xquare.git.user.spi
 import com.xquare.git.git.dto.FindUserInfoRequest
 import com.xquare.git.user.dto.FindUserInfoElement
 import com.xquare.git.user.dto.FindUserListResponse
-import java.util.UUID
+import java.util.*
 
 interface QueryUserPort {
-    suspend fun getName(userId: UUID): FindUserInfoElement
+    suspend fun getNameAndProfileFileName(userId: UUID): FindUserInfoElement
     suspend fun getAllUserInfo(findUserInfoRequest: FindUserInfoRequest): FindUserListResponse
 }

--- a/git-domain/src/main/kotlin/com/xquare/git/git/model/Git.kt
+++ b/git-domain/src/main/kotlin/com/xquare/git/git/model/Git.kt
@@ -7,12 +7,10 @@ import java.util.*
 data class Git(
     val userId: UUID,
     val username: String,
-    val avatarUrl: String,
     val contributions: Int
 ) {
-    fun updateGit(avatarUrl: String, contributions: Int): Git {
+    fun updateGit(contributions: Int): Git {
         return copy(
-            avatarUrl = avatarUrl,
             contributions = contributions
         )
     }

--- a/git-infrastructure/src/main/kotlin/com/xquare/git/persistence/git/mapper/GitMapper.kt
+++ b/git-infrastructure/src/main/kotlin/com/xquare/git/persistence/git/mapper/GitMapper.kt
@@ -11,7 +11,6 @@ class GitMapper {
             Git(
                 userId = userId,
                 username = username,
-                avatarUrl = avatarUrl,
                 contributions = contributions
             )
         }
@@ -22,7 +21,6 @@ class GitMapper {
             GitEntity(
                 userId = userId,
                 username = username,
-                avatarUrl = avatarUrl,
                 contributions = contributions
             )
         }

--- a/git-infrastructure/src/main/kotlin/com/xquare/git/persistence/git/model/GitEntity.kt
+++ b/git-infrastructure/src/main/kotlin/com/xquare/git/persistence/git/model/GitEntity.kt
@@ -19,16 +19,9 @@ class GitEntity(
     val username: String,
 
     contributions: Int,
-
-    avatarUrl: String
-
 ) {
 
     @field: NotNull
     var contributions: Int = contributions
-        protected set
-
-    @field: NotNull
-    var avatarUrl: String = avatarUrl
         protected set
 }

--- a/git-infrastructure/src/main/kotlin/com/xquare/git/persistence/user/spi/UserPersistenceAdapter.kt
+++ b/git-infrastructure/src/main/kotlin/com/xquare/git/persistence/user/spi/UserPersistenceAdapter.kt
@@ -22,7 +22,7 @@ class UserPersistenceAdapter(
     private val scheme: String
 ): UserPort {
 
-    override suspend fun getName(userId: UUID): FindUserInfoElement {
+    override suspend fun getNameAndProfileFileName(userId: UUID): FindUserInfoElement {
         val uri = UriComponentsBuilder.newInstance()
             .scheme(scheme)
             .host(userHost)


### PR DESCRIPTION
1. 현재 로직으로는 업데이트 API 가 유저 한 명당 1초가 걸려서 병렬처리와 비동기를 사용했습니다. (3초대로 줄었습니다.)
2. 깃허브 프로필을 가져오는 것이 아니라 스퀘어 프로필을 가져오도록 수정했습니다.